### PR TITLE
Set Target-Specific Warning Flags in Build Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 
 project(example)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic")
-
 add_library(example src/example.cpp)
 target_include_directories(example PUBLIC include)
+target_compile_options(example PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   include(cmake/CPM.cmake)
@@ -22,6 +21,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     add_executable(example_test test/example_test.cpp)
     target_link_libraries(example_test PRIVATE example Catch2::Catch2WithMain)
+    target_compile_options(example_test PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
     catch_discover_tests(example_test)
   endif()
 endif()


### PR DESCRIPTION
This pull request updates the build configuration to establish warning flags for each target individually rather than applying them globally by setting the `CMAKE_CXX_FLAGS`. It closes #45.