### PR TITLE
Enable Treating Warnings as Errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,20 +36,6 @@ jobs:
           excludes: build/*
           fail-under-line: 80
 
-  check-warning:
-    name: Check Warning
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
-
-      - name: Configure and build this project
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          cxx-flags: -Werror
-          args: -DBUILD_TESTING=ON
-          run-build: true
-
   check-formatting:
     name: Check Formatting
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(example)
 
 add_library(example src/example.cpp)
 target_include_directories(example PUBLIC include)
-target_compile_options(example PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
+target_compile_options(example PRIVATE -Werror -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   include(cmake/CPM.cmake)
@@ -21,7 +21,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     add_executable(example_test test/example_test.cpp)
     target_link_libraries(example_test PRIVATE example Catch2::Catch2WithMain)
-    target_compile_options(example_test PRIVATE -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
+    target_compile_options(example_test PRIVATE -Werror -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
     catch_discover_tests(example_test)
   endif()
 endif()


### PR DESCRIPTION
This pull request introduces the capability to treat warnings as errors by setting the `-Werror` flag. With this change, warnings will be detected during the build process, eliminating the need for a separate job to check warnings. As a result, it closes #46.