### PR TITLE
Organize Jobs in the CI Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,13 +9,14 @@ jobs:
     name: Build Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Configure and build this project
+      - name: Configure project
         uses: threeal/cmake-action@v1.3.0
-        with:
-          run-build: true
+
+      - name: Build project
+        run: cmake --build build
 
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,16 +22,21 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Configure, build, and test this project
+      - name: Configure project
         uses: threeal/cmake-action@v1.3.0
         with:
-          args: -DBUILD_TESTING=ON
-          run-test: true
+          options: BUILD_TESTING=ON
 
-      - name: Check code coverage
+      - name: Build Project
+        run: cmake --build build
+
+      - name: Test Project
+        run: ctest --test-dir build --output-on-failure --no-tests=error
+
+      - name: Check test coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  build:
-    name: Build
+  build-release:
+    name: Build Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,17 +18,25 @@ jobs:
       - name: Build project
         run: cmake --build build
 
-  unit-tests:
-    name: Unit Tests
+  build-testing:
+    name: Build Testing
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
+      - name: Install cmake-format
+        run: pip3 install cmake-format
+
       - name: Configure project
         uses: threeal/cmake-action@v1.3.0
         with:
           options: BUILD_TESTING=ON
+
+      - name: Check formatting
+        run: |
+          cmake --build build --target format
+          git diff --exit-code HEAD
 
       - name: Build Project
         run: cmake --build build
@@ -36,26 +44,8 @@ jobs:
       - name: Test Project
         run: ctest --test-dir build --output-on-failure --no-tests=error
 
-      - name: Check test coverage
+      - name: Check coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*
           fail-under-line: 80
-
-  check-formatting:
-    name: Check Formatting
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.1
-
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
-      - name: Configure CMake
-        run: cmake . -B build
-
-      - name: Check code formatting
-        run: |
-          cmake --build build --target format
-          cmake --build build --target check-format


### PR DESCRIPTION
This pull request organizes jobs in the CI workflow as follows:
- Rename Build job into Build Release job.
- Merge Unit Tests and Check Formatting jobs into Build Testing job.
- Organize steps inside Build Release and Build Testing jobs.

It closes #49.