### PR TITLE
Use CheckWarning.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,16 @@ cmake_minimum_required(VERSION 3.0)
 
 project(example)
 
+include(cmake/CPM.cmake)
+cpmusepackagelock(package-lock)
+
+cpmgetpackage(CheckWarning.cmake)
+
 add_library(example src/example.cpp)
 target_include_directories(example PUBLIC include)
-target_compile_options(example PRIVATE -Werror -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
+target_check_warning(example)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  include(cmake/CPM.cmake)
-  cpmusepackagelock(package-lock)
   cpmgetpackage(Format.cmake)
 
   if(BUILD_TESTING)
@@ -21,7 +24,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     add_executable(example_test test/example_test.cpp)
     target_link_libraries(example_test PRIVATE example Catch2::Catch2WithMain)
-    target_compile_options(example_test PRIVATE -Werror -Wall -Wextra -Wshadow -Wnon-virtual-dtor -Wpedantic)
+    target_check_warning(example_test)
     catch_discover_tests(example_test)
   endif()
 endif()

--- a/package-lock
+++ b/package-lock
@@ -1,6 +1,13 @@
 # CPM Package Lock
 # This file should be committed to version control
 
+# CheckWarning.cmake
+CPMDeclarePackage(CheckWarning.cmake
+  VERSION 1.0.0
+  GITHUB_REPOSITORY threeal/CheckWarning.cmake
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)
 # Format.cmake
 CPMDeclarePackage(Format.cmake
   VERSION 1.7.3


### PR DESCRIPTION
This pull request implements [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) to streamline compiler warning checks, replacing the previous manual implementation that relied on specifying `target_compile_options`. It closes #51.