### PR TITLE
Bump CPM.cmake to v0.38.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.0)
 
 project(example)
 
-file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.6/CPM.cmake
+file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
      ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-     EXPECTED_HASH SHA256=11c3fa5f1ba14f15d31c2fb63dbc8628ee133d81c8d764caad9a8db9e0bacb07)
+     EXPECTED_HASH SHA256=83e5eb71b2bbb8b1f2ad38f1950287a057624e385c238f6087f94cdfc44af9c5)
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
 cpmusepackagelock(package-lock)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(example)
 
 file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
      ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-     EXPECTED_HASH SHA256=83e5eb71b2bbb8b1f2ad38f1950287a057624e385c238f6087f94cdfc44af9c5)
+     EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911)
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
 cpmusepackagelock(package-lock)
 


### PR DESCRIPTION
This pull request introduces the following changes:
- Bump [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to use version [0.38.7](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.38.7).
- Use `EXPECTED_MD5` instead to check for downloaded CPM.cmake file hash.