### PR TITLE
Add Executable Target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,5 +47,7 @@ jobs:
       - name: Check coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
-          excludes: build/*
+          excludes: |
+            build/*
+            src/main.cpp
           fail-under-line: 80

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ target_include_directories(my_fibonacci PUBLIC include)
 set_property(TARGET my_fibonacci PROPERTY CXX_STANDARD 11)
 target_check_warning(my_fibonacci)
 
+add_executable(my_fibonacci_main src/main.cpp)
+target_link_libraries(my_fibonacci_main PUBLIC my_fibonacci)
+set_property(TARGET my_fibonacci_main PROPERTY CXX_STANDARD 11)
+target_check_warning(my_fibonacci_main)
+
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   cpmgetpackage(Format.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/C
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
 cpmusepackagelock(package-lock)
 
+cpmgetpackage(argparse)
 cpmgetpackage(CheckWarning.cmake)
 
 add_library(my_fibonacci src/sequence.cpp)
@@ -15,7 +16,7 @@ set_property(TARGET my_fibonacci PROPERTY CXX_STANDARD 11)
 target_check_warning(my_fibonacci)
 
 add_executable(my_fibonacci_main src/main.cpp)
-target_link_libraries(my_fibonacci_main PUBLIC my_fibonacci)
+target_link_libraries(my_fibonacci_main PUBLIC argparse my_fibonacci)
 set_property(TARGET my_fibonacci_main PROPERTY CXX_STANDARD 11)
 target_check_warning(my_fibonacci_main)
 

--- a/package-lock
+++ b/package-lock
@@ -1,6 +1,13 @@
 # CPM Package Lock
 # This file should be committed to version control
 
+# argparse
+CPMDeclarePackage(argparse
+  VERSION 3.0
+  GITHUB_REPOSITORY p-ranav/argparse
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
   VERSION 1.0.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,18 @@
+#include <cstdlib>
+#include <iostream>
+#include <my_fibonacci/sequence.hpp>
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <n>" << std::endl;
+    return 1;
+  }
+
+  const auto sequence = my_fibonacci::fibonacci_sequence(std::atoi(argv[1]));
+  for (auto val : sequence) {
+    std::cout << val << " ";
+  }
+  std::cout << std::endl;
+
+  return 0;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,24 @@
+#include <argparse/argparse.hpp>
 #include <cstdlib>
 #include <iostream>
 #include <my_fibonacci/sequence.hpp>
 
-int main(int argc, char **argv) {
-  if (argc < 2) {
-    std::cerr << "Usage: " << argv[0] << " <n>" << std::endl;
+int main(int argc, char** argv) {
+  argparse::ArgumentParser program("my_fibonacci_main");
+  program.add_description(
+      "Generate a Fibonacci sequence up to the given number of terms.");
+  program.add_argument("n").help("The number of terms").scan<'i', int>();
+
+  try {
+    program.parse_args(argc, argv);
+  } catch (const std::exception& err) {
+    std::cerr << err.what() << std::endl;
+    std::cerr << program;
     return 1;
   }
 
-  const auto sequence = my_fibonacci::fibonacci_sequence(std::atoi(argv[1]));
+  const auto n = program.get<int>("n");
+  const auto sequence = my_fibonacci::fibonacci_sequence(n);
   for (auto val : sequence) {
     std::cout << val << " ";
   }


### PR DESCRIPTION
This pull request introduces the following changes:
- Add `my_fibonacci_main` executable target for generating Fibonacci sequences from the given target.
- Add [argparse](https://github.com/p-ranav/argparse) as a dependency for parsing arguments in the `my_fibonacci_main` executable.
- Exclude `src/main.cpp` from test coverage check in the CI workflow.

It closes #61.