### PR TITLE
Limit Coverage Flags to Specific Target

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,5 @@ jobs:
       - name: Check coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
-          excludes: |
-            build/*
-            src/main.cpp
+          excludes: build/*
           fail-under-line: 80

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,4 +48,4 @@ jobs:
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*
-          fail-under-line: 80
+          fail-under-line: 100

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,13 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     cpmgetpackage(Catch2)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage -fPIC -O0")
-
     add_executable(my_fibonacci_test test/sequence_test.cpp)
     target_link_libraries(my_fibonacci_test PRIVATE my_fibonacci Catch2::Catch2WithMain)
+
     target_check_warning(my_fibonacci_test)
+    target_compile_options(my_fibonacci_test PRIVATE --coverage -O0)
+    target_link_options(my_fibonacci_test PRIVATE --coverage)
+
     catch_discover_tests(my_fibonacci_test)
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,13 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     cpmgetpackage(Catch2)
     include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
-    add_executable(my_fibonacci_test test/sequence_test.cpp)
-    target_link_libraries(my_fibonacci_test PRIVATE my_fibonacci Catch2::Catch2WithMain)
+    get_target_property(my_fibonacci_SOURCES my_fibonacci SOURCES)
+    add_executable(my_fibonacci_test test/sequence_test.cpp ${my_fibonacci_SOURCES})
+
+    get_target_property(my_fibonacci_INCLUDES my_fibonacci INCLUDE_DIRECTORIES)
+    target_include_directories(my_fibonacci_test PRIVATE ${my_fibonacci_INCLUDES})
+
+    target_link_libraries(my_fibonacci_test PRIVATE Catch2::Catch2WithMain)
 
     target_check_warning(my_fibonacci_test)
     target_compile_options(my_fibonacci_test PRIVATE --coverage -O0)


### PR DESCRIPTION
This pull request introduces the following changes:
- Set coverage flags only to the `my_fibonacci_test` target.
- Rebuild source files of the `my_fibonacci` target instead of linking it to the `my_fibonacci_test` target. This changes prevent the `my_fibonacci` target from having coverage flags enabled.
- Modifies check coverage steps as follows:
  - Removes `src/main.cpp` file from `exclude` input, basically include all files but it's safe now because the coverage will only enabled to source files related in testing.
  - Set `fail-under-line` to be 100, make sure test always covers everything.

It closes #64.