### PR TITLE
Enhance Project Information in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
-project(MyFibonacci)
+project(
+  MyFibonacci
+  VERSION 0.0.0
+  DESCRIPTION "A starter C++ project for generating a Fibonacci sequence."
+  HOMEPAGE_URL https://github.com/threeal/cpp-starter)
 
 # Disable testing build if built as a subproject.
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)


### PR DESCRIPTION
This pull request adds a project version, description, and homepage URL information in the `project` function of `CMakeLists.txt`. This pull request also bumps the minimum CMake version to `3.12` because the `HOMEPAGE_URL` option for `project` function is introduced in that version (see [this](https://cmake.org/cmake/help/latest/command/project.html#options)). It closes #68.