### PR TITLE
Enable Target Export and Installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,11 @@ jobs:
       - name: Install project
         run: cmake --install build --prefix install
 
+      - name: Upload project as artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          path: install
+
   build-testing:
     name: Build Testing
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,9 @@ jobs:
       - name: Build project
         run: cmake --build build
 
+      - name: Install project
+        run: cmake --install build --prefix install
+
   build-testing:
     name: Build Testing
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !.git*
 
 build
+install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,3 +86,17 @@ install(
   NAMESPACE my_fibonacci::
   DESTINATION lib/cmake/MyFibonacci
 )
+
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  MyFibonacciConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+)
+
+install(
+  FILES
+    cmake/MyFibonacciConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/MyFibonacciConfigVersion.cmake
+  DESTINATION lib/cmake/MyFibonacci
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,3 +71,18 @@ if(BUILD_TESTING)
 
   catch_discover_tests(my_fibonacci_test)
 endif()
+
+install(
+  TARGETS my_fibonacci my_fibonacci_main
+  EXPORT my_fibonacci_targets
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  FILE_SET HEADERS
+)
+
+install(
+  EXPORT my_fibonacci_targets
+  FILE MyFibonacciTargets.cmake
+  NAMESPACE my_fibonacci::
+  DESTINATION lib/cmake/MyFibonacci
+)

--- a/cmake/MyFibonacciConfig.cmake
+++ b/cmake/MyFibonacciConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/MyFibonacciTargets.cmake)


### PR DESCRIPTION
This pull request introduces functionality to export and install sample targets within the project template. It also includes steps to install the project and upload it as an artifact in the CI workflow. The changes in this pull request closes #62.