### PR TITLE
Skip CMake Formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Install cmake-format
-        run: pip3 install cmake-format
-
       - name: Configure project
         uses: threeal/cmake-action@v1.3.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,15 +4,20 @@ project(
   MyFibonacci
   VERSION 0.0.0
   DESCRIPTION "A starter C++ project for generating a Fibonacci sequence."
-  HOMEPAGE_URL https://github.com/threeal/cpp-starter)
+  HOMEPAGE_URL https://github.com/threeal/cpp-starter
+)
 
 # Disable testing build if built as a subproject.
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(BUILD_TESTING OFF)
 endif()
 
-file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
-     ${CMAKE_BINARY_DIR}/_deps/CPM.cmake EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911)
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
+  ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
+  EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911
+)
 include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
 cpmusepackagelock(package-lock)
 

--- a/package-lock
+++ b/package-lock
@@ -21,6 +21,8 @@ CPMDeclarePackage(Format.cmake
   GITHUB_REPOSITORY TheLartians/Format.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES
+  OPTIONS
+    "FORMAT_SKIP_CMAKE ON"
 )
 # Catch2
 CPMDeclarePackage(Catch2


### PR DESCRIPTION
This pull request introduces the following changes:
- Disable automatic CMake formatting in this project. 
- Adjust format style in the root's `CMakeLists.txt` file.
- Remove the step used for installing cmake-format from the CI workflow.

It closes #73.