### PR TITLE
Remove CMake Format Config File

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,4 +1,0 @@
-{
-    "enable_markup": false,
-    "line_width": 120
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .*
 !.clang*
-!.cmake*
 !.git*
 
 build


### PR DESCRIPTION
This pull request removes the unused `.cmake-format` configuration file which is should be removed in #74.