### PR TITLE
Rename Sample Targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,23 +53,23 @@ if(BUILD_TESTING)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
   get_target_property(sequence_SOURCES sequence SOURCES)
-  add_executable(my_fibonacci_test test/sequence_test.cpp ${sequence_SOURCES})
+  add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
 
   get_target_property(sequence_HEADER_DIRS sequence HEADER_DIRS)
   get_target_property(sequence_HEADER_SET sequence HEADER_SET)
   target_sources(
-    my_fibonacci_test PRIVATE FILE_SET HEADERS
+    sequence_test PRIVATE FILE_SET HEADERS
     BASE_DIRS ${sequence_HEADER_DIRS}
     FILES ${sequence_HEADER_SET}
   )
 
-  target_link_libraries(my_fibonacci_test PRIVATE Catch2::Catch2WithMain)
+  target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
 
-  target_check_warning(my_fibonacci_test)
-  target_compile_options(my_fibonacci_test PRIVATE --coverage -O0)
-  target_link_options(my_fibonacci_test PRIVATE --coverage)
+  target_check_warning(sequence_test)
+  target_compile_options(sequence_test PRIVATE --coverage -O0)
+  target_link_options(sequence_test PRIVATE --coverage)
 
-  catch_discover_tests(my_fibonacci_test)
+  catch_discover_tests(sequence_test)
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,21 +24,21 @@ cpmusepackagelock(package-lock)
 cpmgetpackage(argparse)
 cpmgetpackage(CheckWarning.cmake)
 
-add_library(my_fibonacci src/sequence.cpp)
+add_library(sequence src/sequence.cpp)
 
 target_sources(
-  my_fibonacci PUBLIC FILE_SET HEADERS
+  sequence PUBLIC FILE_SET HEADERS
   BASE_DIRS include
   FILES include/my_fibonacci/sequence.hpp
 )
 
-set_property(TARGET my_fibonacci PROPERTY CXX_STANDARD 11)
+set_property(TARGET sequence PROPERTY CXX_STANDARD 11)
 if(BUILD_TESTING)
-  target_check_warning(my_fibonacci)
+  target_check_warning(sequence)
 endif()
 
 add_executable(generate_sequence src/main.cpp)
-target_link_libraries(generate_sequence PUBLIC argparse my_fibonacci)
+target_link_libraries(generate_sequence PUBLIC argparse sequence)
 set_property(TARGET generate_sequence PROPERTY CXX_STANDARD 11)
 if(BUILD_TESTING)
   target_check_warning(generate_sequence)
@@ -52,15 +52,15 @@ if(BUILD_TESTING)
   cpmgetpackage(Catch2)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
-  get_target_property(my_fibonacci_SOURCES my_fibonacci SOURCES)
-  add_executable(my_fibonacci_test test/sequence_test.cpp ${my_fibonacci_SOURCES})
+  get_target_property(sequence_SOURCES sequence SOURCES)
+  add_executable(my_fibonacci_test test/sequence_test.cpp ${sequence_SOURCES})
 
-  get_target_property(my_fibonacci_HEADER_DIRS my_fibonacci HEADER_DIRS)
-  get_target_property(my_fibonacci_HEADER_SET my_fibonacci HEADER_SET)
+  get_target_property(sequence_HEADER_DIRS sequence HEADER_DIRS)
+  get_target_property(sequence_HEADER_SET sequence HEADER_SET)
   target_sources(
     my_fibonacci_test PRIVATE FILE_SET HEADERS
-    BASE_DIRS ${my_fibonacci_HEADER_DIRS}
-    FILES ${my_fibonacci_HEADER_SET}
+    BASE_DIRS ${sequence_HEADER_DIRS}
+    FILES ${sequence_HEADER_SET}
   )
 
   target_link_libraries(my_fibonacci_test PRIVATE Catch2::Catch2WithMain)
@@ -73,7 +73,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  TARGETS generate_sequence my_fibonacci
+  TARGETS generate_sequence sequence
   EXPORT my_fibonacci_targets
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,11 +37,11 @@ if(BUILD_TESTING)
   target_check_warning(my_fibonacci)
 endif()
 
-add_executable(my_fibonacci_main src/main.cpp)
-target_link_libraries(my_fibonacci_main PUBLIC argparse my_fibonacci)
-set_property(TARGET my_fibonacci_main PROPERTY CXX_STANDARD 11)
+add_executable(generate_sequence src/main.cpp)
+target_link_libraries(generate_sequence PUBLIC argparse my_fibonacci)
+set_property(TARGET generate_sequence PROPERTY CXX_STANDARD 11)
 if(BUILD_TESTING)
-  target_check_warning(my_fibonacci_main)
+  target_check_warning(generate_sequence)
 endif()
 
 if(BUILD_TESTING)
@@ -73,7 +73,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  TARGETS my_fibonacci my_fibonacci_main
+  TARGETS generate_sequence my_fibonacci
   EXPORT my_fibonacci_targets
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 #include <my_fibonacci/sequence.hpp>
 
 int main(int argc, char** argv) {
-  argparse::ArgumentParser program("my_fibonacci_main");
+  argparse::ArgumentParser program("generate_sequence");
   program.add_description(
       "Generate a Fibonacci sequence up to the given number of terms.");
   program.add_argument("n").help("The number of terms").scan<'i', int>();


### PR DESCRIPTION
This pull request renames the sample targets as follows:
- Rename the executable target from `my_fibonacci_main` to `generate_sequence`.
- Rename the library target from `my_fibonacci` to `sequence`.
- Rename the test target from `my_fibonacci_test` to `sequence_test`.

It closes #77.