### PR TITLE
Bump CMake Minimum Required to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.23)
 
 project(
   MyFibonacci


### PR DESCRIPTION
This pull request bumps the CMake minimum required version to 3.23 because of the usage of `target_sources`'s file set in this template which is introduced on that version. This change previously should be part of #76.