### PR TITLE
Divide Workflow into Build and Test Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,27 @@
+name: Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build-Project:
+    name: Build Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Configure project
+        uses: threeal/cmake-action@v1.3.0
+
+      - name: Build project
+        run: cmake --build build
+
+      - name: Install project
+        run: cmake --install build --prefix install
+
+      - name: Upload project as artifact
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          path: install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,16 +12,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Configure project
+      - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
 
-      - name: Build project
+      - name: Build Project
         run: cmake --build build
 
-      - name: Install project
+      - name: Install Project
         run: cmake --install build --prefix install
 
-      - name: Upload project as artifact
+      - name: Upload Project as Artifact
         uses: actions/upload-artifact@v3.1.3
         with:
           path: install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [main]
 jobs:
-  test-project:
-    name: Test Project
+  check-project:
+    name: Check Project
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,6 +21,18 @@ jobs:
         run: |
           cmake --build build --target format
           git diff --exit-code HEAD
+
+  test-project:
+    name: Test Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Configure project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_TESTING=ON
 
       - name: Build Project
         run: cmake --build build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,33 +1,12 @@
-name: CI
+name: Test
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  build-release:
-    name: Build Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-
-      - name: Configure project
-        uses: threeal/cmake-action@v1.3.0
-
-      - name: Build project
-        run: cmake --build build
-
-      - name: Install project
-        run: cmake --install build --prefix install
-
-      - name: Upload project as artifact
-        uses: actions/upload-artifact@v3.1.3
-        with:
-          path: install
-
-  build-testing:
-    name: Build Testing
+  test-project:
+    name: Test Project
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Configure project
+      - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
           options: BUILD_TESTING=ON
 
-      - name: Check formatting
+      - name: Check Format
         run: |
           cmake --build build --target format
           git diff --exit-code HEAD
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
-      - name: Configure project
+      - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
           options: BUILD_TESTING=ON
@@ -40,7 +40,7 @@ jobs:
       - name: Test Project
         run: ctest --test-dir build --output-on-failure --no-tests=error
 
-      - name: Check coverage
+      - name: Check Coverage
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # C++ Starter
 
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/cpp-starter/ci.yaml?branch=main&style=flat-square)](https://github.com/threeal/cpp-starter/actions/workflows/ci.yaml)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/cpp-starter/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/cpp-starter/actions/workflows/build.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/cpp-starter/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/cpp-starter/actions/workflows/test.yaml)
 
 The C++ Starter is a [GitHub repository template](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template) that provides a minimalistic boilerplate to kickstart your [C++](https://isocpp.org) project. This template offers a streamlined foundation, complete with predefined file structures, essential tools, and recommended settings, ensuring a swift and efficient start to your C++ development journey.


### PR DESCRIPTION
This pull request divides the `ci.yaml` workflow into two separate workflows, namely `build.yaml` and `test.yaml`. Additionally, it separates the steps for checking code formatting in the `test-project` job into a new `check-project` job. The steps are also renamed to use uppercase names for clarity. This addresses and closes #70.