### PR TITLE
Remove Unused `cstdlib` Include

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <argparse/argparse.hpp>
-#include <cstdlib>
 #include <iostream>
 #include <my_fibonacci/sequence.hpp>
 


### PR DESCRIPTION
This pull request simply removes the unused `cstdlib` include in the `main.cpp` file.