### PR TITLE
Bump CheckWarning.cmake to Version 2.0.1

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -10,7 +10,7 @@ CPMDeclarePackage(argparse
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 2.0.0
+  VERSION 2.0.1
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request bumps the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake/) dependency to version [2.0.1](https://github.com/threeal/CheckWarning.cmake/releases/tag/v2.0.1).