### PR TITLE
Define C++ Standard with `target_compile_features`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ target_sources(
   BASE_DIRS include
   FILES include/my_fibonacci/sequence.hpp
 )
-set_property(TARGET sequence PROPERTY CXX_STANDARD 11)
+target_compile_features(sequence PRIVATE cxx_std_11)
 
 add_executable(generate_sequence src/main.cpp)
 target_link_libraries(generate_sequence PUBLIC argparse sequence)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ set_property(TARGET sequence PROPERTY CXX_STANDARD 11)
 
 add_executable(generate_sequence src/main.cpp)
 target_link_libraries(generate_sequence PUBLIC argparse sequence)
-set_property(TARGET generate_sequence PROPERTY CXX_STANDARD 11)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   enable_testing()


### PR DESCRIPTION
This pull request resolves #90 by utilizing the `target_compile_features` in replace of the `set_property` to set C++ standard for a specific target. It also removes setting C++ standard for `generate_sequence` target because it is unnecessary.