### PR TITLE
Add MSVC Support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,13 +7,23 @@ on:
 jobs:
   build-Project:
     name: Build Project
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            cxx: g++
+          - os: windows
+            cxx: cl
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
+        with:
+          cxx-compiler: ${{ matrix.cxx }}
 
       - name: Build Project
         run: cmake --build build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,19 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu
-            cxx: g++
-          - os: windows
-            cxx: cl
+        os: [ubuntu, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
 
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
-        with:
-          cxx-compiler: ${{ matrix.cxx }}
 
       - name: Build Project
         run: cmake --build build --config Release

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,4 +34,5 @@ jobs:
       - name: Upload Project as Artifact
         uses: actions/upload-artifact@v4.0.0
         with:
+          name: package-${{ matrix.os }}
           path: install

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
           cxx-compiler: ${{ matrix.cxx }}
 
       - name: Build Project
-        run: cmake --build build
+        run: cmake --build build --config Release
 
       - name: Install Project
         run: cmake --install build --prefix install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,15 @@ jobs:
 
   test-project:
     name: Test Project
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu
+            cxx: g++
+          - os: windows
+            cxx: cl
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -32,6 +40,7 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
+          cxx-compiler: ${{ matrix.cxx }}
           options: BUILD_TESTING=ON
 
       - name: Build Project
@@ -41,6 +50,7 @@ jobs:
         run: ctest --test-dir build --output-on-failure --no-tests=error
 
       - name: Check Coverage
+        if: ${{ matrix.cxx != 'cl' }}
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,11 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu
-            cxx: g++
-          - os: windows
-            cxx: cl
+        os: [ubuntu, windows]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -40,7 +36,6 @@ jobs:
       - name: Configure Project
         uses: threeal/cmake-action@v1.3.0
         with:
-          cxx-compiler: ${{ matrix.cxx }}
           options: BUILD_TESTING=ON
 
       - name: Build Project
@@ -50,7 +45,7 @@ jobs:
         run: ctest --test-dir build --output-on-failure --no-tests=error
 
       - name: Check Coverage
-        if: ${{ matrix.cxx != 'cl' }}
+        if: ${{ matrix.os != 'windows' }}
         uses: threeal/gcovr-action@v1.0.0
         with:
           excludes: build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
 
   target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
 
-  target_compile_options(sequence_test PRIVATE --coverage -O0)
-  target_link_options(sequence_test PRIVATE --coverage)
+  if(NOT MSVC)
+    target_compile_options(sequence_test PRIVATE --coverage -O0)
+    target_link_options(sequence_test PRIVATE --coverage)
+  endif()
 
   catch_discover_tests(sequence_test)
 endif()


### PR DESCRIPTION
This pull request addresses #92 by introducing the following changes:
- Runs `build-project` and `test-project` jobs on both Ubuntu and Windows OS.
- Build project using release configuration in the `build-project` job.
- Prevent check coverage step to run on Windows OS in the `test-project` job.
- Disable setting the coverage flags on MSVC compiler.