### PR TITLE
Fix `build-project `Job Naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
 jobs:
-  build-Project:
+  build-project:
     name: Build Project
     runs-on: ${{ matrix.os }}-latest
     strategy:


### PR DESCRIPTION
This pull request simply fixes the naming of the `build-project` which is previously named as `build-Project`.