### PR TITLE
Refactor Header Files Specification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ cpmgetpackage(argparse)
 
 add_library(sequence src/sequence.cpp)
 target_sources(
-  sequence PUBLIC FILE_SET HEADERS
+  sequence PUBLIC
+  FILE_SET HEADERS
   BASE_DIRS include
   FILES include/my_fibonacci/sequence.hpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,16 +41,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
   get_target_property(sequence_SOURCES sequence SOURCES)
-  add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
-
   get_target_property(sequence_HEADER_DIRS sequence HEADER_DIRS)
-  get_target_property(sequence_HEADER_SET sequence HEADER_SET)
-  target_sources(
-    sequence_test PRIVATE FILE_SET HEADERS
-    BASE_DIRS ${sequence_HEADER_DIRS}
-    FILES ${sequence_HEADER_SET}
-  )
 
+  add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
+  target_include_directories(sequence_test PRIVATE ${sequence_HEADER_DIRS})
   target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
 
   if(NOT MSVC)


### PR DESCRIPTION
This pull request introduces the following changes:
- Utilizes the `target_include_directories` function in replace of the `target_sources(FILE_SET)` function in the `sequence_test` target. The `target_sources(FILE_SET)` function is replaced because the only benefit of this function is only when we are going to install the header files of a target, but since we are not going to install the `sequence_test` target, then we reverted it to a classic implementation using the `target_include_directories` function instead.
- Updates the style of the `target_sources(FILE_SET)` function call.