### PR TITLE
Set CMake Project Languages to C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(
   VERSION 0.0.0
   DESCRIPTION "A starter C++ project for generating a Fibonacci sequence."
   HOMEPAGE_URL https://github.com/threeal/cpp-starter
+  LANGUAGES CXX
 )
 
 file(


### PR DESCRIPTION
This pull request simply sets the `LANGUAGES` property to `CXX` in the `project` function of `CMakeLists.txt`. This change is made to set the project to only allows C++ language.