### PR TITLE
Add `CPM.cmake` Module File

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,9 @@ project(
   LANGUAGES CXX
 )
 
-file(
-  DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
-  ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-  EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911
-)
-include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+include(CPM)
 cpmusepackagelock(package-lock)
 
 cpmgetpackage(argparse)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,7 @@
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.7/CPM.cmake
+  ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
+  EXPECTED_MD5 14ea07dfb484cad5db4ee1c75fd6a911
+)
+include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)


### PR DESCRIPTION
This pull request resolves #103 by adding a local `cmake/CPM.cmake` module file that contains lines for downloading and including the actual `CPM.cmake` module file. These changes will simplify the contents of the root's `CMakeLists.txt`.