### PR TITLE
Add `CheckCoverage.cmake` Module File

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,19 +45,8 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   target_include_directories(sequence_test PRIVATE ${sequence_HEADER_DIRS})
   target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
 
-  if(NOT MSVC)
-    target_compile_options(sequence_test PRIVATE --coverage -O0 -fno-exceptions)
-    target_link_options(sequence_test PRIVATE --coverage)
-
-    get_target_property(sequence_test_SOURCES sequence_test SOURCES)
-    foreach(SOURCE ${sequence_test_SOURCES})
-      set(GCDA ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/sequence_test.dir/${SOURCE}.gcda)
-      add_custom_command(
-        TARGET sequence_test PRE_LINK
-        COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
-      )
-    endforeach()
-  endif()
+  include(CheckCoverage)
+  target_check_coverage(sequence_test)
 
   catch_discover_tests(sequence_test)
 endif()

--- a/cmake/CheckCoverage.cmake
+++ b/cmake/CheckCoverage.cmake
@@ -1,0 +1,20 @@
+function(target_check_coverage TARGET)
+  if(MSVC)
+    message(WARNING "Test coverage check is not available on MSVC")
+    return()
+  endif()
+
+  target_compile_options(${TARGET} PRIVATE --coverage -O0 -fno-exceptions)
+  target_link_options(${TARGET} PRIVATE --coverage)
+
+  get_target_property(TARGET_BINARY_DIR ${TARGET} BINARY_DIR)
+  get_target_property(TARGET_SOURCES ${TARGET} SOURCES)
+
+  foreach(SOURCE ${TARGET_SOURCES})
+    set(GCDA ${TARGET_BINARY_DIR}/CMakeFiles/${TARGET}.dir/${SOURCE}.gcda)
+    add_custom_command(
+      TARGET ${TARGET} PRE_LINK
+      COMMAND ${CMAKE_COMMAND} -E rm -f ${GCDA}
+    )
+  endforeach()
+endfunction()


### PR DESCRIPTION
This pull request resolves #104 by introducing the `CheckCoverage.cmake` module file that contains a `target_check_coverage` function for enabling test coverage check on a specific target. This change will simplify the content of the root's `CMakeLists.txt` by moving some CMake lines into a separate module.