### PR TITLE
Bump CheckWarning.cmake to v2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   enable_testing()
 
   find_package(CheckWarning REQUIRED)
+  include(CheckWarning)
   add_check_warning()
 
   find_package(Format REQUIRED)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -12,7 +12,7 @@ function(cpm_add_argparse)
 endfunction()
 
 function(cpm_add_check_warning)
-  cpmaddpackage(gh:threeal/CheckWarning.cmake@2.0.1)
+  cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.0)
 endfunction()
 
 function(cpm_add_format)

--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -1,3 +1,12 @@
+if(CheckWarning_FOUND)
+  return()
+endif()
+
+find_package(CheckWarning QUIET CONFIG)
+if(CheckWarning_FOUND)
+  return()
+endif()
+
 include(CPM)
 cpm_add_check_warning()
 

--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -1,2 +1,4 @@
 include(CPM)
 cpm_add_check_warning()
+
+list(APPEND CMAKE_MODULE_PATH ${CheckWarning_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request introduces the following changes:
- Bumps CheckWarning.cmake to version 2.1.0.
- Modifies the `FindCheckWarning.cmake` module to attempt to find the CheckWarning.cmake config file before adding it via CPM.cmake.