### PR TITLE
Utilize FixFormat.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
 
   include(Catch)
   catch_discover_tests(sequence_test)
+
+  add_custom_target(format)
+  add_dependencies(format sequence_format generate_sequence_format sequence_test_format)
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   include(CheckWarning)
   add_check_warning()
 
+  find_package(FixFormat REQUIRED)
+  include(FixFormat)
+  target_fix_format(sequence)
+  target_fix_format(generate_sequence)
+
   find_package(Format REQUIRED)
 
   find_package(Catch2 REQUIRED)
@@ -44,6 +49,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
 
   include(CheckCoverage)
   target_check_coverage(sequence_test)
+  target_fix_format(sequence_test)
 
   include(Catch)
   catch_discover_tests(sequence_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND BUILD_TESTING)
   target_fix_format(sequence)
   target_fix_format(generate_sequence)
 
-  find_package(Format REQUIRED)
-
   find_package(Catch2 REQUIRED)
 
   get_target_property(sequence_SOURCES sequence SOURCES)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -15,6 +15,10 @@ function(cpm_add_check_warning)
   cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.0)
 endfunction()
 
+function(cpm_add_fix_format)
+  cpmaddpackage(gh:threeal/FixFormat.cmake@1.0.0)
+endfunction()
+
 function(cpm_add_format)
   cpmaddpackage(
     Format.cmake

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -19,15 +19,6 @@ function(cpm_add_fix_format)
   cpmaddpackage(gh:threeal/FixFormat.cmake@1.0.0)
 endfunction()
 
-function(cpm_add_format)
-  cpmaddpackage(
-    Format.cmake
-    VERSION 1.7.3
-    GITHUB_REPOSITORY TheLartians/Format.cmake
-    OPTIONS "FORMAT_SKIP_CMAKE ON"
-  )
-endfunction()
-
 function(cpm_add_catch2)
   cpmaddpackage(gh:catchorg/Catch2@3.5.1)
 endfunction()

--- a/cmake/FindFixFormat.cmake
+++ b/cmake/FindFixFormat.cmake
@@ -1,0 +1,13 @@
+if(FixFormat_FOUND)
+  return()
+endif()
+
+find_package(FixFormat QUIET CONFIG)
+if(FixFormat_FOUND)
+  return()
+endif()
+
+include(CPM)
+cpm_add_fix_format()
+
+list(APPEND CMAKE_MODULE_PATH ${FixFormat_SOURCE_DIR}/cmake)

--- a/cmake/FindFormat.cmake
+++ b/cmake/FindFormat.cmake
@@ -1,2 +1,0 @@
-include(CPM)
-cpm_add_format()


### PR DESCRIPTION
This pull request resolves #114 by introducing the following changes:
- Utilizes FixFormat.cmake to format source codes of each target before the compilation step.
- Removes the usage of Format.cmake.
- Add a `format` target that depends on all format targets.