### PR TITLE
Bump Catch2 to Version 3.5.2

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -20,5 +20,5 @@ function(cpm_add_fix_format)
 endfunction()
 
 function(cpm_add_catch2)
-  cpmaddpackage(gh:catchorg/Catch2@3.5.1)
+  cpmaddpackage(gh:catchorg/Catch2@3.5.2)
 endfunction()


### PR DESCRIPTION
This pull request simply bumps Catch2 to [version 3.5.2](https://github.com/catchorg/Catch2/releases/tag/v3.5.2).