### PR TITLE
Add Include Guard in Sample Modules

### DIFF
--- a/cmake/CheckCoverage.cmake
+++ b/cmake/CheckCoverage.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 function(target_check_coverage TARGET)
   if(MSVC)
     message(WARNING "Test coverage check is not available on MSVC")


### PR DESCRIPTION
This pull request resolves #121 by calling the `include_guard` function at the start of the `CheckCoverage.cmake` module.