### PR TITLE
Bump FixFormat.cmake to Version 1.1.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check Format
         run: |
-          cmake --build build --target format
+          cmake --build build --target format-all
           git diff --exit-code HEAD
 
   test-project:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,11 +32,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     include(CheckWarning)
     add_check_warning()
 
-    find_package(FixFormat REQUIRED)
-    include(FixFormat)
-    target_fix_format(sequence)
-    target_fix_format(generate_sequence)
-
     find_package(Catch2 REQUIRED)
 
     get_target_property(sequence_SOURCES sequence SOURCES)
@@ -48,13 +43,13 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 
     include(CheckCoverage)
     target_check_coverage(sequence_test)
-    target_fix_format(sequence_test)
 
     include(Catch)
     catch_discover_tests(sequence_test)
 
-    add_custom_target(format)
-    add_dependencies(format sequence_format generate_sequence_format sequence_test_format)
+    find_package(FixFormat REQUIRED)
+    include(FixFormat)
+    add_fix_format()
   endif()
 
   install(

--- a/cmake/FindFixFormat.cmake
+++ b/cmake/FindFixFormat.cmake
@@ -8,6 +8,6 @@ if(FixFormat_FOUND)
 endif()
 
 include(CPM)
-cpmaddpackage(gh:threeal/FixFormat.cmake@1.0.0)
+cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.0)
 
 list(APPEND CMAKE_MODULE_PATH ${FixFormat_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request introduces the following changes:
- Bumps the FixFormat.cmake to version [1.1.0](https://github.com/threeal/FixFormat.cmake/releases/tag/v1.1.0).
- Utilizes the `add_fix_format` function in replace of the `target_fix_format` function.