### PR TITLE
Organize `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,30 +40,35 @@ target_compile_features(sequence PRIVATE cxx_std_11)
 add_executable(generate_sequence src/main.cpp)
 target_link_libraries(generate_sequence PUBLIC argparse::argparse sequence)
 
+# Declare test targets if it is not a subproject and testing is enabled.
+if(NOT SUBPROJECT AND BUILD_TESTING)
+  enable_testing()
+
+  find_package(Catch2 REQUIRED)
+
+  get_target_property(sequence_SOURCES sequence SOURCES)
+  get_target_property(sequence_HEADER_DIRS sequence HEADER_DIRS)
+
+  add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
+  target_include_directories(sequence_test PRIVATE ${sequence_HEADER_DIRS})
+  target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
+
+  include(CheckCoverage)
+  target_check_coverage(sequence_test)
+
+  include(Catch)
+  catch_discover_tests(sequence_test)
+endif()
+
+# Enable automatic formatting if it is not a subproject and testing is enabled.
+if(NOT SUBPROJECT AND BUILD_TESTING)
+  find_package(FixFormat REQUIRED)
+  include(FixFormat)
+  add_fix_format()
+endif()
+
+# Declare export and install targets if it is not a subproject.
 if(NOT SUBPROJECT)
-  if(BUILD_TESTING)
-    enable_testing()
-
-    find_package(Catch2 REQUIRED)
-
-    get_target_property(sequence_SOURCES sequence SOURCES)
-    get_target_property(sequence_HEADER_DIRS sequence HEADER_DIRS)
-
-    add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
-    target_include_directories(sequence_test PRIVATE ${sequence_HEADER_DIRS})
-    target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
-
-    include(CheckCoverage)
-    target_check_coverage(sequence_test)
-
-    include(Catch)
-    catch_discover_tests(sequence_test)
-
-    find_package(FixFormat REQUIRED)
-    include(FixFormat)
-    add_fix_format()
-  endif()
-
   install(
     TARGETS generate_sequence sequence
     EXPORT my_fibonacci_targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project(
   LANGUAGES CXX
 )
 
+# Check if this project is a subproject of another project.
+if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  set(SUBPROJECT TRUE)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 find_package(argparse REQUIRED)
@@ -24,7 +29,7 @@ target_compile_features(sequence PRIVATE cxx_std_11)
 add_executable(generate_sequence src/main.cpp)
 target_link_libraries(generate_sequence PUBLIC argparse::argparse sequence)
 
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+if(NOT SUBPROJECT)
   if(BUILD_TESTING)
     enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ if(SUBPROJECT)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
 endif()
 
+# Enable warning checks if it is not a subproject and testing is enabled.
+if(NOT SUBPROJECT AND BUILD_TESTING)
+  find_package(CheckWarning REQUIRED)
+  include(CheckWarning)
+  add_check_warning()
+endif()
+
 find_package(argparse REQUIRED)
 
 add_library(sequence src/sequence.cpp)
@@ -36,10 +43,6 @@ target_link_libraries(generate_sequence PUBLIC argparse::argparse sequence)
 if(NOT SUBPROJECT)
   if(BUILD_TESTING)
     enable_testing()
-
-    find_package(CheckWarning REQUIRED)
-    include(CheckWarning)
-    add_check_warning()
 
     find_package(Catch2 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,11 @@ if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(SUBPROJECT TRUE)
 endif()
 
+# Append the module path and export to the parent scope if is a subproject.
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+if(SUBPROJECT)
+  set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
+endif()
 
 find_package(argparse REQUIRED)
 


### PR DESCRIPTION
This pull request organize the `CMakeLists.txt` file as follows:
- Add a `SUBPROJECT ` variable to determine whether the project is a subproject of another project or not.
- Append the `CMAKE_MODULE_PATH` variable to the parent scope if the project is a subproject of another project.
- Separate the declaration of warning checks, testing, formatting, and installation targets.