### PR TITLE
Bump CheckWarning.cmake to Version 2.1.1

### DIFF
--- a/cmake/FindCheckWarning.cmake
+++ b/cmake/FindCheckWarning.cmake
@@ -8,6 +8,6 @@ if(CheckWarning_FOUND)
 endif()
 
 include(CPM)
-cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.0)
+cpmaddpackage(gh:threeal/CheckWarning.cmake@2.1.1)
 
 list(APPEND CMAKE_MODULE_PATH ${CheckWarning_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request simply bumps the CheckWarning.cmake to version [2.1.1](https://github.com/threeal/CheckWarning.cmake/releases/tag/v2.1.1).