### PR TITLE
Bump Catch2 to Version 3.5.3

### DIFF
--- a/cmake/FindCatch2.cmake
+++ b/cmake/FindCatch2.cmake
@@ -8,6 +8,6 @@ if(Catch2_FOUND)
 endif()
 
 include(CPM)
-cpmaddpackage(gh:catchorg/Catch2@3.5.2)
+cpmaddpackage(gh:catchorg/Catch2@3.5.3)
 
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)


### PR DESCRIPTION
This pull request simply bumps the Catch2 to version [3.5.3](https://github.com/catchorg/Catch2/releases/tag/v3.5.3).