### PR TITLE
Bump FixFormat.cmake to Version 1.1.1

### DIFF
--- a/cmake/FindFixFormat.cmake
+++ b/cmake/FindFixFormat.cmake
@@ -8,6 +8,6 @@ if(FixFormat_FOUND)
 endif()
 
 include(CPM)
-cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.0)
+cpmaddpackage(gh:threeal/FixFormat.cmake@1.1.1)
 
 list(APPEND CMAKE_MODULE_PATH ${FixFormat_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This pull request simply bumps the FixFormat.cmake module to [version 1.1.1](https://github.com/threeal/FixFormat.cmake/releases/tag/v1.1.1).