### PR TITLE
Utilize CTest Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
         run: cmake --build build
 
       - name: Test Project
-        run: ctest --test-dir build --output-on-failure --no-tests=error
+        uses: threeal/ctest-action@v1.0.0
 
       - name: Check Coverage
         if: ${{ matrix.os != 'windows' }}


### PR DESCRIPTION
This pull request resolves #132 by using the CTest Action as a replacement for the `ctest` command to run tests for this project in the GitHub Actions workflows.