### PR TITLE
Bump Catch2 to Version 3.5.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(NOT SUBPROJECT AND BUILD_TESTING)
   find_package(Catch2 QUIET)
   if(NOT Catch2_FOUND)
     get_cpm()
-    cpmaddpackage(gh:catchorg/Catch2@3.5.3)
+    cpmaddpackage(gh:catchorg/Catch2@3.5.4)
     list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
   endif()
 


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.5.4](https://github.com/catchorg/Catch2/releases/tag/v3.5.4).