### PR TITLE
Bump Catch2 to Version 3.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(NOT SUBPROJECT AND BUILD_TESTING)
 
   find_package(Catch2 QUIET)
   if(NOT Catch2_FOUND)
-    cpmaddpackage(gh:catchorg/Catch2@3.5.4)
+    cpmaddpackage(gh:catchorg/Catch2@3.6.0)
     list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
   endif()
 


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.6.0](https://github.com/catchorg/Catch2/releases/tag/v3.6.0).