### PR TITLE
Reorder Included Headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+IncludeBlocks: Preserve

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
-#include <argparse/argparse.hpp>
-#include <iostream>
 #include <my_fibonacci/sequence.hpp>
+
+#include <argparse/argparse.hpp>
+
+#include <iostream>
 
 int main(int argc, char** argv) {
   argparse::ArgumentParser program("generate_sequence");

--- a/src/sequence.cpp
+++ b/src/sequence.cpp
@@ -1,5 +1,6 @@
-#include <algorithm>
 #include <my_fibonacci/sequence.hpp>
+
+#include <algorithm>
 
 namespace my_fibonacci {
 

--- a/test/sequence_test.cpp
+++ b/test/sequence_test.cpp
@@ -1,5 +1,6 @@
-#include <catch2/catch_test_macros.hpp>
 #include <my_fibonacci/sequence.hpp>
+
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("test fibonacci sequence") {
   CHECK(my_fibonacci::fibonacci_sequence(-1) == std::vector<int>{});


### PR DESCRIPTION
This pull request resolves #150 by reordering the included headers and setting the `IncludeBlocks` option in the Clang Format to `Preserve`.