### PR TITLE
Utilize UT for Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,12 @@ if(NOT SUBPROJECT AND BUILD_TESTING)
 
   find_package(ut QUIET)
   if(NOT ut_FOUND)
-    cpmaddpackage(gh:boost-ext/ut@2.0.1)
+    cpmaddpackage(
+      NAME ut
+      GITHUB_REPOSITORY boost-ext/ut
+      VERSION 2.0.1
+      OPTIONS "BOOST_UT_DISABLE_MODULE ON"
+    )
   endif()
 
   get_target_property(sequence_SOURCES sequence SOURCES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,10 +62,9 @@ target_link_libraries(generate_sequence PUBLIC argparse::argparse sequence)
 if(NOT SUBPROJECT AND BUILD_TESTING)
   enable_testing()
 
-  find_package(Catch2 QUIET)
-  if(NOT Catch2_FOUND)
-    cpmaddpackage(gh:catchorg/Catch2@3.6.0)
-    list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+  find_package(ut QUIET)
+  if(NOT ut_FOUND)
+    cpmaddpackage(gh:boost-ext/ut@2.0.1)
   endif()
 
   get_target_property(sequence_SOURCES sequence SOURCES)
@@ -73,13 +72,12 @@ if(NOT SUBPROJECT AND BUILD_TESTING)
 
   add_executable(sequence_test test/sequence_test.cpp ${sequence_SOURCES})
   target_include_directories(sequence_test PRIVATE ${sequence_HEADER_DIRS})
-  target_link_libraries(sequence_test PRIVATE Catch2::Catch2WithMain)
+  target_link_libraries(sequence_test PRIVATE Boost::ut)
 
   include(CheckCoverage)
   target_check_coverage(sequence_test)
 
-  include(Catch)
-  catch_discover_tests(sequence_test)
+  add_test(NAME "Sequence Test" COMMAND sequence_test)
 endif()
 
 # Enable automatic formatting if it is not a subproject and testing is enabled.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The C++ Starter is a [GitHub repository template](https://docs.github.com/en/rep
 
 - Utilizes [CMake](https://cmake.org/) as the build system generator.
 - Integrates [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake/) for efficient package management.
-- Incorporates [Catch2](https://github.com/catchorg/Catch2) as the testing framework.
+- Incorporates [UT](https://boost-ext.github.io/ut) as the testing framework.
 - Enforces consistent code formatting through [Format.cmake](https://github.com/TheLartians/Format.cmake).
 - Implements static analysis by enabling warnings using [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake/).
 - Comes with a preconfigured [GitHub Actions](https://github.com/features/actions) workflow for continuous integration.

--- a/test/sequence_test.cpp
+++ b/test/sequence_test.cpp
@@ -1,11 +1,16 @@
 #include <my_fibonacci/sequence.hpp>
 
-#include <catch2/catch_test_macros.hpp>
+#include <boost/ut.hpp>
 
-TEST_CASE("test fibonacci sequence") {
-  CHECK(my_fibonacci::fibonacci_sequence(-1) == std::vector<int>{});
-  CHECK(my_fibonacci::fibonacci_sequence(0) == std::vector<int>{});
-  CHECK(my_fibonacci::fibonacci_sequence(1) == std::vector<int>{1});
-  CHECK(my_fibonacci::fibonacci_sequence(2) == std::vector<int>{1, 1});
-  CHECK(my_fibonacci::fibonacci_sequence(5) == std::vector<int>{1, 1, 2, 3, 5});
+using my_fibonacci::fibonacci_sequence;
+using namespace boost::ut;
+
+int main() {
+  should("generate a Fibonacci sequence") = [] {
+    expect(fibonacci_sequence(-1) == std::vector<int>{});
+    expect(fibonacci_sequence(0) == std::vector<int>{});
+    expect(fibonacci_sequence(1) == std::vector<int>{1});
+    expect(fibonacci_sequence(2) == std::vector<int>{1, 1});
+    expect(fibonacci_sequence(5) == std::vector<int>{1, 1, 2, 3, 5});
+  };
 }


### PR DESCRIPTION
This pull request resolves #102 by utilizing [UT](https://boost-ext.github.io/ut) as the testing framework, replacing [Catch2](https://github.com/catchorg/Catch2).