### PR TITLE
Specify Test Config in CI Workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Test Project
         uses: threeal/ctest-action@v1.0.0
+        with:
+          build-config: Debug
 
       - name: Check Coverage
         if: ${{ matrix.os != 'windows' }}


### PR DESCRIPTION
This pull request specifies the build configuration during testing by setting the `build-config` option during the Test Package step in the Test workflow.