### PR TITLE
Separate Check Package Job into Check Workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,23 @@
+name: Check
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  check-project:
+    name: Check Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+
+      - name: Configure Project
+        uses: threeal/cmake-action@v1.3.0
+        with:
+          options: BUILD_TESTING=ON
+
+      - name: Check Formatting
+        run: |
+          cmake --build build --target format-all
+          git diff --exit-code HEAD

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,23 +5,6 @@ on:
   push:
     branches: [main]
 jobs:
-  check-project:
-    name: Check Project
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.6
-
-      - name: Configure Project
-        uses: threeal/cmake-action@v1.3.0
-        with:
-          options: BUILD_TESTING=ON
-
-      - name: Check Format
-        run: |
-          cmake --build build --target format-all
-          git diff --exit-code HEAD
-
   test-project:
     name: Test Project
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
This pull request resolves #154 by simply separating the `check-project` job in the `test` workflow into a new `check` workflow.