### PR TITLE
Bump argparse to Version 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 find_package(argparse QUIET)
 if(NOT argparse_FOUND)
-  cpmaddpackage(gh:p-ranav/argparse@3.0)
+  cpmaddpackage(gh:p-ranav/argparse@3.1)
 endif()
 
 add_library(sequence src/sequence.cpp)


### PR DESCRIPTION
This pull request simply bumps the argparse to version [3.1](https://github.com/p-ranav/argparse/releases/tag/v3.1).