### PR TITLE
Bump UT to Version 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(MY_FIBONACCI_ENABLE_TESTS)
     cpmaddpackage(
       NAME ut
       GITHUB_REPOSITORY boost-ext/ut
-      VERSION 2.0.1
+      VERSION 2.1.0
       OPTIONS "BOOST_UT_DISABLE_MODULE ON"
     )
   endif()


### PR DESCRIPTION
This pull request simply bumps UT to version [2.1.0](https://github.com/boost-ext/ut/releases/tag/v2.1.0).