### PR TITLE
Bump CPM.cmake to Version 0.40.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ option(MY_FIBONACCI_ENABLE_INSTALL "Enable install targets."
 function(cpmaddpackage)
   file(
     DOWNLOAD
-    https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.0/CPM.cmake
+    https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.40.1/CPM.cmake
     ${CMAKE_BINARY_DIR}/_deps/CPM.cmake
-    EXPECTED_MD5 6c9866a0aa0f804a36fe8c3866fb8a2c
+    EXPECTED_MD5 a5467d77aa63a1197ea4e1644623acb7
   )
   include(${CMAKE_BINARY_DIR}/_deps/CPM.cmake)
   cpmaddpackage(${ARGN})


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.40.1](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.40.1).