### PR TITLE
Bump UT to Version 2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(MY_FIBONACCI_ENABLE_TESTS)
     cpmaddpackage(
       NAME ut
       GITHUB_REPOSITORY boost-ext/ut
-      VERSION 2.1.0
+      VERSION 2.1.1
       OPTIONS "BOOST_UT_DISABLE_MODULE ON"
     )
   endif()


### PR DESCRIPTION
This pull request bumps [UT](https://github.com/boost-ext/ut) to version [2.1.1](https://github.com/boost-ext/ut/releases/tag/v2.1.1).