### PR TITLE
Remove Dependabot Label Configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,4 +6,3 @@ updates:
       interval: daily
     commit-message:
       prefix: chore
-    labels: [chore]


### PR DESCRIPTION
This pull request resolves #191 by removing the `labels` entry from the `dependabot.yaml` configuration file.