### PR TITLE
Bump argparse to Version 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 find_package(argparse QUIET)
 if(NOT argparse_FOUND)
-  cpmaddpackage(gh:p-ranav/argparse@3.1)
+  cpmaddpackage(gh:p-ranav/argparse@3.2)
 endif()
 
 add_library(sequence src/sequence.cpp)


### PR DESCRIPTION
This pull request simply bumps argparse to version [3.2](https://github.com/p-ranav/argparse/releases/tag/v3.2).