### PR TITLE
Remove Upload Project Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,3 @@ jobs:
 
       - name: Install Project
         run: cmake --install build --prefix install
-
-      - name: Upload Project as Artifact
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: package-${{ matrix.os }}
-          path: install


### PR DESCRIPTION
This pull request resolves #205 by removing the "Upload Project as Artifact" step from the Build workflow.